### PR TITLE
Allow to inherit one page from another

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-class class IndexPage < Tram::Page
+class IndexPage < Tram::Page
   # See dry-initializer
   param  :account
   option :readonly, optional: true
@@ -50,6 +50,22 @@ end
 IndexPage.new(Account.find(99)).to_h
 IndexPage.new(Account.find(99)).to_h(except: :collection)
 IndexPage.new(Account.find(99)).to_h(only: :collection)
+```
+
+Inheritance of page objects is supported:
+
+```ruby
+class FancyIndexPage < IndexPage
+  inherit_section :title
+  section         :fancy_collection
+  inherit_section :index_url, if: :readonly_on?
+
+  def fancy_collection
+    collection.map(&:fancy)
+  end
+end
+
+FancyIndexPage.new(Account.find(99)).to_h # => { :title => "…", fancy_collection: […] } 
 ```
 
 ## Development

--- a/lib/tram/page.rb
+++ b/lib/tram/page.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "dry-initializer"
+require_relative "page/section"
+
 class Tram::Page
   extend ::Dry::Initializer
 
@@ -14,7 +17,14 @@ class Tram::Page
 
       section = Section.new(name, options)
       sections[name] = section
-      define_method(name, &section.block) if section.block
+      define_method(name, &section.value) if section.value
+    end
+
+    def inherit_section(name, option_overrides={})
+      name = name.to_sym
+      parent_section = superclass.sections[name]
+      options = Tram::Page::Section.dry_initializer.attributes(parent_section)
+      section(name, options.merge(option_overrides))
     end
 
     def url_helper(name)

--- a/lib/tram/page.rb
+++ b/lib/tram/page.rb
@@ -28,10 +28,10 @@ class Tram::Page
   end
 
   def to_h(except: nil, only: nil, **)
-    obj = self.class.sections.values.map { |s| s.call(self) }.reduce({}, :merge)
-    obj = obj.reject { |k, _| Array(except).map(&:to_sym).include? k } if except
-    obj = obj.select { |k, _| Array(only).map(&:to_sym).include? k }   if only
-    obj
+    sections = self.class.sections.dup
+    sections.select! { |k, _| Array(only).include? k }   if only
+    sections.reject! { |k, _| Array(except).include? k } if except
+    sections.map { |_, section| section.call(self) }.reduce({}, :merge!)
   end
 
   private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "dry/initializer"
 require "tram/page"
 require "support/blank_page"
 require "support/example_page"
+require "support/inherited_page"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/inherited_page.rb
+++ b/spec/support/inherited_page.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class InheritedPage < ExamplePage
+  inherit_section :foo
+  inherit_section :bar, if: :no_bar
+  section :bam
+
+  def bam
+    baz.upcase
+  end
+
+  def no_bar
+    !bar
+  end
+end

--- a/spec/tram/inherited_page_spec.rb
+++ b/spec/tram/inherited_page_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe InheritedPage do
+  subject { described_class.new("test") }
+
+  it "returns data hash with new and without skipped fields" do
+    expect(subject.to_h).to eq(foo: "test", bam: "TEST")
+  end
+
+  it "doesn't change behaviour of the parent class" do
+    expect(described_class.superclass.new("test").to_h).to \
+      eq(bar: "test", foo: "test", baz: "test")
+  end
+end


### PR DESCRIPTION
To allow reuse of common sections and to allow to add or remove sections for specific cases.

Have replaced an array of sections to hash of sections as it is easier to work with now and allows to avoid full array scan to check for duplicated sections.