### PR TITLE
Refactor section definitions (extract sections)

### DIFF
--- a/lib/tram/page/section.rb
+++ b/lib/tram/page/section.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Tram::Page
+  #
+  # Contains class-level definition (name and options) for a section
+  # with a method [#call] that extracts the section part of hash
+  # from an instance of [Tram::Page]
+  #
+  class Section
+    extend Dry::Initializer
+    param  :name,   proc(&:to_sym)
+    option :method, proc(&:to_s),    default: -> { name }, as: :method_name
+    option :value,  proc(&:to_proc), optional: true,       as: :block
+    option :if,     proc(&:to_s),    optional: true,       as: :positive
+    option :unless, proc(&:to_s),    optional: true,       as: :negative
+    option :skip,   true.method(:&), optional: true
+
+    # @param  [Tram::Page] page
+    # @return [Hash] a part of the section
+    def call(page)
+      skip_on?(page) ? {} : { name => value_at(page) }
+    end
+
+    private
+
+    def skip_on?(page)
+      return true if skip
+      return true if positive && !page.public_send(positive)
+      return true if negative &&  page.public_send(negative)
+    end
+
+    def value_at(page)
+      block ? page.instance_exec(&block) : page.public_send(method_name)
+    end
+  end
+end


### PR DESCRIPTION
@gzigzigzeo Here I've just the proposed refactoring without adding any new features.

@envek Now you can prepare you changes by reloading section definitions either implicitly, or explicitly (for example, you could add `option :reload, true.method(:&), optional: true` to the section and check it in `Tram::Page#section`). Be aware of https://github.com/tram-rb/tram-page/pull/5/files#diff-f279a26eb24bc37345ac55d12c85bbb0R13

I think, you guys should define an appropriate behavior that suites the both commercial projects.