### PR TITLE
Allow to overload sections explicitly

### DIFF
--- a/lib/tram/page.rb
+++ b/lib/tram/page.rb
@@ -9,12 +9,12 @@ class Tram::Page
     attr_accessor :i18n_scope
 
     # Defines a section of the page as a reference to its public method,
-    # and creates/reloads the method if necessary.
+    # and creates/overloads the method if necessary.
     #
     # @param  [#to_sym] name The name of the **section**
     #
-    # @option [Boolean] :reload
-    #   If this definition can reload a previous one
+    # @option [Boolean] :overload
+    #   If this definition can overload a previous one
     # @option [Proc] :value (nil)
     #   A new content of the referred method
     # @option options [#to_sym] :method (name)
@@ -26,9 +26,9 @@ class Tram::Page
     #
     # @return [self] itself
     #
-    def section(name, reload: false, value: nil, **options)
+    def section(name, overload: false, value: nil, **options)
       name = name.to_sym
-      raise "Section :#{name} already exists" if !reload && sections.key?(name)
+      raise "Section #{name} already exists" if !overload && sections.key?(name)
 
       section = Section.new(name, options)
       define_method(section.source, &value) if value

--- a/lib/tram/page/section.rb
+++ b/lib/tram/page/section.rb
@@ -2,6 +2,7 @@
 
 class Tram::Page
   #
+  # @private
   # Contains class-level definition (name and options) for a section
   # with a method [#call] that extracts the section part of hash
   # from an instance of [Tram::Page]
@@ -9,11 +10,9 @@ class Tram::Page
   class Section
     extend Dry::Initializer
     param  :name,   proc(&:to_sym)
-    option :method, proc(&:to_s),    default: -> { name }, as: :method_name
-    option :value,  proc(&:to_proc), optional: true,       as: :block
-    option :if,     proc(&:to_s),    optional: true,       as: :positive
-    option :unless, proc(&:to_s),    optional: true,       as: :negative
-    option :skip,   true.method(:&), optional: true
+    option :method, proc(&:to_s), default: -> { name }, as: :source
+    option :if,     proc(&:to_s), optional: true,       as: :positive
+    option :unless, proc(&:to_s), optional: true,       as: :negative
 
     # @param  [Tram::Page] page
     # @return [Hash] a part of the section
@@ -24,13 +23,12 @@ class Tram::Page
     private
 
     def skip_on?(page)
-      return true if skip
       return true if positive && !page.public_send(positive)
       return true if negative &&  page.public_send(negative)
     end
 
     def value_at(page)
-      block ? page.instance_exec(&block) : page.public_send(method_name)
+      page.public_send(source)
     end
   end
 end

--- a/spec/tram/duplicate_sections_spec.rb
+++ b/spec/tram/duplicate_sections_spec.rb
@@ -3,11 +3,19 @@
 require "spec_helper"
 
 describe BlankPage do
+  let(:klass) { Class.new(described_class) }
+
+  before { klass.section :alfa, value: -> { :foo }, reload: true }
+
   it "raises on section duplicate" do
-    described_class.section :alfa
-    described_class.section :beta
-    expect { described_class.section :alfa }.to raise_error(
-      /Section alfa already exists/
-    )
+    expect { klass.section :alfa, value: -> { :bar } }
+      .to raise_error(StandardError, /Section :alfa already exists/)
+  end
+
+  it "allows to reload section explicitly" do
+    expect { klass.section :alfa, value: -> { :bar }, reload: true }
+      .to change { klass.new.alfa }
+      .from(:foo)
+      .to(:bar)
   end
 end

--- a/spec/tram/duplicate_sections_spec.rb
+++ b/spec/tram/duplicate_sections_spec.rb
@@ -5,15 +5,15 @@ require "spec_helper"
 describe BlankPage do
   let(:klass) { Class.new(described_class) }
 
-  before { klass.section :alfa, value: -> { :foo }, reload: true }
+  before { klass.section :alfa, value: -> { :foo } }
 
   it "raises on section duplicate" do
     expect { klass.section :alfa, value: -> { :bar } }
-      .to raise_error(StandardError, /Section :alfa already exists/)
+      .to raise_error(StandardError, /Section alfa already exists/)
   end
 
-  it "allows to reload section explicitly" do
-    expect { klass.section :alfa, value: -> { :bar }, reload: true }
+  it "allows to overload section explicitly" do
+    expect { klass.section :alfa, value: -> { :bar }, overload: true }
       .to change { klass.new.alfa }
       .from(:foo)
       .to(:bar)


### PR DESCRIPTION
With `reload: true` option you can reload previous definition of the section.
(prepared for inheritance feature from @Envek).